### PR TITLE
Implement offloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Thanks to *CoolStar* for writing open source [RealTek driver](https://github.com
 
 - [ ] Efficient MSI/MSI-X interrupt handling
 - [ ] Offloading
-  - [ ] Checksums
+  - [x] Checksums
   - [ ] Large send offload
 - [ ] Energy Efficient Ethernet
 - [ ] RSS

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Thanks to *CoolStar* for writing open source [RealTek driver](https://github.com
 ## TODO
 
 - [ ] Efficient MSI/MSI-X interrupt handling
-- [ ] Offloading
+- [x] Offloading
   - [x] Checksums
-  - [ ] Large send offload
+  - [x] Large send offload
 - [ ] Energy Efficient Ethernet
 - [ ] RSS
 - [ ] Enable support for more NIC models

--- a/adapter.cpp
+++ b/adapter.cpp
@@ -184,7 +184,7 @@ void
 IgbAdapterSetOffloadCapabilities(
 	_In_ IGB_ADAPTER const* adapter)
 {
-	/*NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES txChecksumOffloadCapabilities;
+	NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES txChecksumOffloadCapabilities;
 
 	NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES_INIT(
 		&txChecksumOffloadCapabilities,
@@ -198,14 +198,14 @@ IgbAdapterSetOffloadCapabilities(
 		NetAdapterOffloadLayer4FlagTcpWithOptions |
 		NetAdapterOffloadLayer4FlagUdp;
 	txChecksumOffloadCapabilities.Layer4HeaderOffsetLimit = 511;
-	NetAdapterOffloadSetTxChecksumCapabilities(adapter->NetAdapter, &txChecksumOffloadCapabilities);*/
+	NetAdapterOffloadSetTxChecksumCapabilities(adapter->NetAdapter, &txChecksumOffloadCapabilities);
 
-	/*NET_ADAPTER_OFFLOAD_IEEE8021Q_TAG_CAPABILITIES ieee8021qTagOffloadCapabilities;
+	NET_ADAPTER_OFFLOAD_IEEE8021Q_TAG_CAPABILITIES ieee8021qTagOffloadCapabilities;
 	NET_ADAPTER_OFFLOAD_IEEE8021Q_TAG_CAPABILITIES_INIT(
 		&ieee8021qTagOffloadCapabilities,
 		NetAdapterOffloadIeee8021PriorityTaggingFlag |
 		NetAdapterOffloadIeee8021VlanTaggingFlag);
-	NetAdapterOffloadSetIeee8021qTagCapabilities(adapter->NetAdapter, &ieee8021qTagOffloadCapabilities);*/
+	NetAdapterOffloadSetIeee8021qTagCapabilities(adapter->NetAdapter, &ieee8021qTagOffloadCapabilities);
 }
 
 _Use_decl_annotations_

--- a/adapter.cpp
+++ b/adapter.cpp
@@ -162,6 +162,52 @@ IgbAdapterSetDatapathCapabilities(
 	NetAdapterSetDataPathCapabilities(adapter->NetAdapter, &txCapabilities, &rxCapabilities);
 }
 
+static
+void
+EvtAdapterOffloadSetTxChecksum(
+	_In_ NETADAPTER netAdapter,
+	_In_ NETOFFLOAD offload)
+{
+	IGB_ADAPTER* adapter = IgbGetAdapterContext(netAdapter);
+
+	/*adapter->TxIpHwChkSum = NetOffloadIsTxChecksumIPv4Enabled(offload);
+	adapter->TxTcpHwChkSum = NetOffloadIsTxChecksumTcpEnabled(offload);
+	adapter->TxUdpHwChkSum = NetOffloadIsTxChecksumUdpEnabled(offload);*/
+	DBGPRINT("EvtAdapterOffloadSetTxChecksum IP: %d TCP: %d UDP: %d\n",
+		NetOffloadIsTxChecksumIPv4Enabled(offload),
+		NetOffloadIsTxChecksumTcpEnabled(offload),
+		NetOffloadIsTxChecksumUdpEnabled(offload));
+}
+
+static
+void
+IgbAdapterSetOffloadCapabilities(
+	_In_ IGB_ADAPTER const* adapter)
+{
+	/*NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES txChecksumOffloadCapabilities;
+
+	NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES_INIT(
+		&txChecksumOffloadCapabilities,
+		NetAdapterOffloadLayer3FlagIPv4NoOptions |
+		NetAdapterOffloadLayer3FlagIPv4WithOptions |
+		NetAdapterOffloadLayer3FlagIPv6NoExtensions |
+		NetAdapterOffloadLayer3FlagIPv6WithExtensions,
+		EvtAdapterOffloadSetTxChecksum);
+	txChecksumOffloadCapabilities.Layer4Flags =
+		NetAdapterOffloadLayer4FlagTcpNoOptions |
+		NetAdapterOffloadLayer4FlagTcpWithOptions |
+		NetAdapterOffloadLayer4FlagUdp;
+	txChecksumOffloadCapabilities.Layer4HeaderOffsetLimit = 511;
+	NetAdapterOffloadSetTxChecksumCapabilities(adapter->NetAdapter, &txChecksumOffloadCapabilities);*/
+
+	/*NET_ADAPTER_OFFLOAD_IEEE8021Q_TAG_CAPABILITIES ieee8021qTagOffloadCapabilities;
+	NET_ADAPTER_OFFLOAD_IEEE8021Q_TAG_CAPABILITIES_INIT(
+		&ieee8021qTagOffloadCapabilities,
+		NetAdapterOffloadIeee8021PriorityTaggingFlag |
+		NetAdapterOffloadIeee8021VlanTaggingFlag);
+	NetAdapterOffloadSetIeee8021qTagCapabilities(adapter->NetAdapter, &ieee8021qTagOffloadCapabilities);*/
+}
+
 _Use_decl_annotations_
 NTSTATUS
 IgbAdapterStart(
@@ -174,6 +220,7 @@ IgbAdapterStart(
 	IgbAdapterSetLinkLayerCapabilities(adapter);
 	IgbAdapterSetReceiveFilterCapabilities(adapter);
 	IgbAdapterSetDatapathCapabilities(adapter);
+	IgbAdapterSetOffloadCapabilities(adapter);
 
 	IgbUpdateReceiveFilters(adapter);
 

--- a/adapter.cpp
+++ b/adapter.cpp
@@ -164,19 +164,36 @@ IgbAdapterSetDatapathCapabilities(
 
 static
 void
+EvtAdapterOffloadSetGso(
+	_In_ NETADAPTER netAdapter,
+	_In_ NETOFFLOAD offload)
+{
+	IGB_ADAPTER* adapter = IgbGetAdapterContext(netAdapter);
+
+	DBGPRINT("EvtAdapterOffloadSetGso IPv4: %d IPV6: %d\n",
+		NetOffloadIsLsoIPv4Enabled(offload),
+		NetOffloadIsLsoIPv6Enabled(offload));
+
+	adapter->LSOv4 = NetOffloadIsLsoIPv4Enabled(offload);
+	adapter->LSOv6 = NetOffloadIsLsoIPv6Enabled(offload);
+}
+
+static
+void
 EvtAdapterOffloadSetTxChecksum(
 	_In_ NETADAPTER netAdapter,
 	_In_ NETOFFLOAD offload)
 {
 	IGB_ADAPTER* adapter = IgbGetAdapterContext(netAdapter);
 
-	/*adapter->TxIpHwChkSum = NetOffloadIsTxChecksumIPv4Enabled(offload);
-	adapter->TxTcpHwChkSum = NetOffloadIsTxChecksumTcpEnabled(offload);
-	adapter->TxUdpHwChkSum = NetOffloadIsTxChecksumUdpEnabled(offload);*/
 	DBGPRINT("EvtAdapterOffloadSetTxChecksum IP: %d TCP: %d UDP: %d\n",
 		NetOffloadIsTxChecksumIPv4Enabled(offload),
 		NetOffloadIsTxChecksumTcpEnabled(offload),
 		NetOffloadIsTxChecksumUdpEnabled(offload));
+
+	adapter->TxIpHwChkSum = NetOffloadIsTxChecksumIPv4Enabled(offload);
+	adapter->TxTcpHwChkSum = NetOffloadIsTxChecksumTcpEnabled(offload);
+	adapter->TxUdpHwChkSum = NetOffloadIsTxChecksumUdpEnabled(offload);
 }
 
 static
@@ -186,19 +203,22 @@ EvtAdapterOffloadSetRxChecksum(
 	_In_ NETOFFLOAD offload)
 {
 	IGB_ADAPTER* adapter = IgbGetAdapterContext(netAdapter);
-	u32 rxcsum = E1000_READ_REG(&adapter->Hw, E1000_RXCSUM);
 
 	DBGPRINT("EvtAdapterOffloadSetRxChecksum IP: %d TCP: %d UDP: %d\n",
 		NetOffloadIsRxChecksumIPv4Enabled(offload),
 		NetOffloadIsRxChecksumTcpEnabled(offload),
 		NetOffloadIsRxChecksumUdpEnabled(offload));
 
+	u32 rxcsum = E1000_READ_REG(&adapter->Hw, E1000_RXCSUM);
 	rxcsum &= ~(E1000_RXCSUM_IPOFL | E1000_RXCSUM_TUOFL);
 	rxcsum |= NetOffloadIsRxChecksumIPv4Enabled(offload) ? E1000_RXCSUM_IPOFL : 0;
 	rxcsum |= NetOffloadIsRxChecksumTcpEnabled(offload) ? E1000_RXCSUM_TUOFL : 0;
-	rxcsum |= NetOffloadIsRxChecksumUdpEnabled(offload) ? E1000_RXCSUM_TUOFL : 0;
-	
+	rxcsum |= NetOffloadIsRxChecksumUdpEnabled(offload) ? E1000_RXCSUM_TUOFL : 0;	
 	E1000_WRITE_REG(&adapter->Hw, E1000_RXCSUM, rxcsum);
+
+	adapter->RxIpHwChkSum = NetOffloadIsRxChecksumIPv4Enabled(offload);
+	adapter->RxTcpHwChkSum = NetOffloadIsRxChecksumTcpEnabled(offload);
+	adapter->RxUdpHwChkSum = NetOffloadIsRxChecksumUdpEnabled(offload);
 }
 
 static
@@ -206,6 +226,21 @@ void
 IgbAdapterSetOffloadCapabilities(
 	_In_ IGB_ADAPTER const* adapter)
 {
+	/*NET_ADAPTER_OFFLOAD_GSO_CAPABILITIES gsoOffloadCapabilities;
+	NET_ADAPTER_OFFLOAD_GSO_CAPABILITIES_INIT(
+		&gsoOffloadCapabilities,
+		NetAdapterOffloadLayer3FlagIPv4NoOptions |
+		NetAdapterOffloadLayer3FlagIPv4WithOptions |
+		NetAdapterOffloadLayer3FlagIPv6NoExtensions |
+		NetAdapterOffloadLayer3FlagIPv6WithExtensions,
+		NetAdapterOffloadLayer4FlagTcpNoOptions |
+		NetAdapterOffloadLayer4FlagTcpWithOptions |
+		NetAdapterOffloadLayer4FlagUdp,
+		240,
+		1,
+		EvtAdapterOffloadSetGso);
+	NetAdapterOffloadSetGsoCapabilities(adapter->NetAdapter, &gsoOffloadCapabilities);*/
+
 	NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES txChecksumOffloadCapabilities;
 	NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES_INIT(
 		&txChecksumOffloadCapabilities,

--- a/adapter.cpp
+++ b/adapter.cpp
@@ -226,7 +226,7 @@ void
 IgbAdapterSetOffloadCapabilities(
 	_In_ IGB_ADAPTER const* adapter)
 {
-	/*NET_ADAPTER_OFFLOAD_GSO_CAPABILITIES gsoOffloadCapabilities;
+	NET_ADAPTER_OFFLOAD_GSO_CAPABILITIES gsoOffloadCapabilities;
 	NET_ADAPTER_OFFLOAD_GSO_CAPABILITIES_INIT(
 		&gsoOffloadCapabilities,
 		NetAdapterOffloadLayer3FlagIPv4NoOptions |
@@ -236,10 +236,11 @@ IgbAdapterSetOffloadCapabilities(
 		NetAdapterOffloadLayer4FlagTcpNoOptions |
 		NetAdapterOffloadLayer4FlagTcpWithOptions |
 		NetAdapterOffloadLayer4FlagUdp,
-		240,
+		0xffff,
 		1,
 		EvtAdapterOffloadSetGso);
-	NetAdapterOffloadSetGsoCapabilities(adapter->NetAdapter, &gsoOffloadCapabilities);*/
+	gsoOffloadCapabilities.Layer4HeaderOffsetLimit = 240;
+	NetAdapterOffloadSetGsoCapabilities(adapter->NetAdapter, &gsoOffloadCapabilities);
 
 	NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES txChecksumOffloadCapabilities;
 	NET_ADAPTER_OFFLOAD_TX_CHECKSUM_CAPABILITIES_INIT(

--- a/adapter.h
+++ b/adapter.h
@@ -41,14 +41,14 @@ typedef struct _IGB_ADAPTER
 	//FLOW_CTRL FlowControl;
 	//UINT16 VlanID;
 	//ULONG64 MaxSpeed;
-	//BOOLEAN TxIpHwChkSum;
-	//BOOLEAN TxTcpHwChkSum;
-	//BOOLEAN TxUdpHwChkSum;
-	//BOOLEAN RxIpHwChkSum;
-	//BOOLEAN RxTcpHwChkSum;
-	//BOOLEAN RxUdpHwChkSum;
-	//BOOLEAN LSOv4;
-	//BOOLEAN LSOv6;
+	BOOLEAN TxIpHwChkSum;
+	BOOLEAN TxTcpHwChkSum;
+	BOOLEAN TxUdpHwChkSum;
+	BOOLEAN RxIpHwChkSum;
+	BOOLEAN RxTcpHwChkSum;
+	BOOLEAN RxUdpHwChkSum;
+	BOOLEAN LSOv4;
+	BOOLEAN LSOv6;
 
 	struct e1000_hw Hw;
 } IGB_ADAPTER, *PIGB_ADAPTER;

--- a/igb.inx
+++ b/igb.inx
@@ -46,7 +46,7 @@ AddReg                  = NetworkAddress.kw
 ;AddReg                  = VlanID.kw
 ;AddReg                  = FlowControl.kw
 AddReg                  = OffloadChecksum.kw
-AddReg                  = PriorityVlanTag.kw
+;AddReg                  = PriorityVlanTag.kw
 ;AddReg                  = LSO.kw
 
 [ndi.reg]

--- a/igb.inx
+++ b/igb.inx
@@ -46,8 +46,8 @@ AddReg                  = NetworkAddress.kw
 ;AddReg                  = VlanID.kw
 ;AddReg                  = FlowControl.kw
 AddReg                  = OffloadChecksum.kw
-;AddReg                  = PriorityVlanTag.kw
-;AddReg                  = LSO.kw
+AddReg                  = PriorityVlanTag.kw
+AddReg                  = LSO.kw
 
 [ndi.reg]
 ; TODO: Update these if your device is not Ethernet.

--- a/igb.inx
+++ b/igb.inx
@@ -45,8 +45,8 @@ AddReg                  = ndi.reg
 AddReg                  = NetworkAddress.kw
 ;AddReg                  = VlanID.kw
 ;AddReg                  = FlowControl.kw
-;AddReg                  = OffloadChecksum.kw
-;AddReg                  = PriorityVlanTag.kw
+AddReg                  = OffloadChecksum.kw
+AddReg                  = PriorityVlanTag.kw
 ;AddReg                  = LSO.kw
 
 [ndi.reg]

--- a/interrupt.cpp
+++ b/interrupt.cpp
@@ -63,10 +63,6 @@ EvtInterruptIsr(
 		return TRUE;
 	}
 
-	// Mask off the interrupts
-	E1000_WRITE_REG(hw, E1000_IMC, 0xffffffff);
-	E1000_WRITE_FLUSH(hw);
-
 	if ((reg_icr & (E1000_ICR_FER | E1000_ICR_DOUTSYNC | E1000_ICR_DRSTA | E1000_ICR_ECCER | E1000_ICR_THS)) &&
 		!InterlockedExchange8(&interrupt->PciInterrupt, TRUE))
 	{
@@ -152,9 +148,4 @@ EvtInterruptDpc(
 		hw->mac.get_link_status = 1;
 		IgbCheckLinkStatus(adapter);
 	}
-
-	WdfInterruptAcquireLock(adapter->Interrupt->Handle);
-	E1000_WRITE_REG(hw, E1000_IMS, IMS_ENABLE_MASK);
-	E1000_WRITE_FLUSH(hw);
-	WdfInterruptReleaseLock(adapter->Interrupt->Handle);
 }

--- a/rxqueue.cpp
+++ b/rxqueue.cpp
@@ -140,7 +140,7 @@ RxIndicateReceives(
 
 			if ((ptype & E1000_RXDADV_PKTTYPE_TCP) == E1000_RXDADV_PKTTYPE_TCP)
 				packet->Layout.Layer4Type = NetPacketLayer4TypeTcp;
-			else if ((ptype & E1000_RXDADV_PKTTYPE_TCP) == E1000_RXDADV_PKTTYPE_UDP)
+			else if ((ptype & E1000_RXDADV_PKTTYPE_UDP) == E1000_RXDADV_PKTTYPE_UDP)
 				packet->Layout.Layer4Type = NetPacketLayer4TypeUdp;
 
 			if ((rxd->wb.upper.status_error & E1000_RXD_STAT_IPCS) != 0)

--- a/rxqueue.cpp
+++ b/rxqueue.cpp
@@ -7,8 +7,8 @@
 #include "interrupt.h"
 #include "link.h"
 
-//#undef DBGPRINT
-//#define DBGPRINT(...)
+#undef DBGPRINT
+#define DBGPRINT(...)
 
 _Use_decl_annotations_
 NTSTATUS

--- a/rxqueue.h
+++ b/rxqueue.h
@@ -14,8 +14,9 @@ typedef struct _IGB_RXQUEUE {
 	USHORT NumRxDesc;
 
 	NET_EXTENSION LogicalAddressExtension;
+	NET_EXTENSION ChecksumExtension;
 	NET_EXTENSION Ieee8021qExtension;
-	/*NET_EXTENSION ChecksumExtension;
+	/*
 	NET_EXTENSION VirtualAddressExtension;
 	NET_EXTENSION HashValueExtension;
 	*/

--- a/rxqueue.h
+++ b/rxqueue.h
@@ -8,7 +8,7 @@ typedef struct _IGB_RXQUEUE {
 
 	// descriptor information
 	WDFCOMMONBUFFER RxdArray;
-	struct e1000_rx_desc* RxdBase;
+	union e1000_adv_rx_desc* RxdBase;
 	size_t RxdSize;
 
 	USHORT NumRxDesc;

--- a/rxqueue.h
+++ b/rxqueue.h
@@ -14,10 +14,11 @@ typedef struct _IGB_RXQUEUE {
 	USHORT NumRxDesc;
 
 	NET_EXTENSION LogicalAddressExtension;
+	NET_EXTENSION Ieee8021qExtension;
 	/*NET_EXTENSION ChecksumExtension;
 	NET_EXTENSION VirtualAddressExtension;
 	NET_EXTENSION HashValueExtension;
-	NET_EXTENSION Ieee8021qExtension;*/
+	*/
 
 	ULONG QueueId;
 } IGB_RXQUEUE, *PIGB_RXQUEUE;

--- a/txqueue.cpp
+++ b/txqueue.cpp
@@ -184,7 +184,7 @@ IgbPostContextDescriptor(
 				ctxd->type_tucmd_mlhl |= E1000_ADVTXD_TUCMD_IPV4;
 			else if (NetPacketIsIpv6(packet))
 				ctxd->type_tucmd_mlhl |= E1000_ADVTXD_TUCMD_IPV6;
-			olinfo_status |= E1000_TXD_POPTS_IXSM;
+			olinfo_status |= E1000_TXD_POPTS_IXSM << 8;
 		}
 
 		if (checksumInfo->Layer4 == NetPacketTxChecksumActionRequired)
@@ -193,7 +193,7 @@ IgbPostContextDescriptor(
 				ctxd->type_tucmd_mlhl |= E1000_ADVTXD_TUCMD_L4T_TCP;
 			else if (packet->Layout.Layer4Type == NetPacketLayer4TypeUdp)
 				ctxd->type_tucmd_mlhl |= E1000_ADVTXD_TUCMD_L4T_UDP;
-			olinfo_status |= E1000_TXD_POPTS_TXSM;
+			olinfo_status |= E1000_TXD_POPTS_TXSM << 8;
 		}
 	}
 

--- a/txqueue.cpp
+++ b/txqueue.cpp
@@ -255,7 +255,9 @@ IgbTransmitPackets(
 			u32 cmd_type_len = E1000_ADVTXD_DCMD_DEXT | E1000_ADVTXD_DTYP_DATA | E1000_ADVTXD_DCMD_IFCS;
 			u32 olinfo_status = 0;//((u16)packet->) << E1000_ADVTXD_PAYLEN_SHIFT;
 			u32 packet_length = 0;
+
 			tcb->FirstTxDescIdx = tx->TxDescIndex;
+			tcb->NumTxDesc = 0;
 
 			if (needContextDescriptor)
 			{
@@ -276,7 +278,7 @@ IgbTransmitPackets(
 			olinfo_status |= packet_length << E1000_ADVTXD_PAYLEN_SHIFT;
 
 			fragmentIndex = packet->FragmentIndex;
-			for (tcb->NumTxDesc = 0; fragmentIndex != fragmentEndIndex; tcb->NumTxDesc++)
+			for (; fragmentIndex != fragmentEndIndex; tcb->NumTxDesc++)
 			{
 				NET_FRAGMENT const* fragment = NetRingGetFragmentAtIndex(fragmentRing, fragmentIndex);
 				union e1000_adv_tx_desc* txd = &tx->TxdBase[tx->TxDescIndex];

--- a/txqueue.h
+++ b/txqueue.h
@@ -25,11 +25,11 @@ typedef struct _IGB_TXQUEUE {
 	USHORT NumTxDesc;
 	USHORT TxDescIndex;
 
-	//NET_EXTENSION ChecksumExtension;
 	//NET_EXTENSION GsoExtension;
 	//NET_EXTENSION VirtualAddressExtension;
 	NET_EXTENSION LogicalAddressExtension;
-	//NET_EXTENSION Ieee8021qExtension;
+	NET_EXTENSION Ieee8021qExtension;
+	NET_EXTENSION ChecksumExtension;
 
 	ULONG QueueId;
 	UINT8 Priority;

--- a/txqueue.h
+++ b/txqueue.h
@@ -25,10 +25,9 @@ typedef struct _IGB_TXQUEUE {
 	USHORT NumTxDesc;
 	USHORT TxDescIndex;
 
-	//NET_EXTENSION GsoExtension;
-	//NET_EXTENSION VirtualAddressExtension;
 	NET_EXTENSION LogicalAddressExtension;
 	NET_EXTENSION Ieee8021qExtension;
+	NET_EXTENSION GsoExtension;
 	NET_EXTENSION ChecksumExtension;
 
 	ULONG QueueId;

--- a/txqueue.h
+++ b/txqueue.h
@@ -19,7 +19,7 @@ typedef struct _IGB_TXQUEUE {
 
 	// descriptor information
 	WDFCOMMONBUFFER TxdArray;
-	struct e1000_tx_desc* TxdBase;
+	union e1000_adv_tx_desc* TxdBase;
 	size_t TxSize;
 
 	USHORT NumTxDesc;


### PR DESCRIPTION
Add support for offloading the following operations:
- Large TCP/UDP sends
- IPv4/TCP/UDP checksum on transmit and receive

Partial implementation of VLAN options. We don't set the NIC per-queue or global options in the registers, so the reception side is mostly no-op.